### PR TITLE
Polish empty jobs state

### DIFF
--- a/src/app/jobs-polish.css
+++ b/src/app/jobs-polish.css
@@ -1,0 +1,71 @@
+.jobs-filter-trigger {
+  min-height: 2.8rem;
+  border-radius: 999px !important;
+  padding-inline: 1rem 1.12rem !important;
+  box-shadow: var(--shadow-card) !important;
+}
+
+.jobs-filter-trigger[data-active="true"] {
+  border-color: var(--brand-border) !important;
+  background: var(--surface-solid) !important;
+  color: var(--text-strong) !important;
+}
+
+.dark .jobs-filter-trigger {
+  border-color: rgba(148, 163, 184, 0.12) !important;
+  background: rgba(8, 13, 29, 0.72) !important;
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.045) !important;
+}
+
+.dark .jobs-filter-trigger:hover,
+.dark .jobs-filter-trigger[data-active="true"] {
+  border-color: rgba(129, 140, 248, 0.28) !important;
+  background: rgba(255, 255, 255, 0.1) !important;
+  color: #ffffff !important;
+}
+
+.jobs-empty-state {
+  position: relative;
+  isolation: isolate;
+  border-color: transparent !important;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--surface-raised) 88%, transparent), color-mix(in srgb, var(--surface-solid) 84%, transparent)) !important;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--border-subtle) 72%, transparent),
+    0 22px 58px rgba(31, 45, 74, 0.09),
+    inset 0 1px 0 rgba(255, 255, 255, 0.34) !important;
+}
+
+.dark .jobs-empty-state {
+  background:
+    linear-gradient(180deg, rgba(12, 19, 36, 0.92), rgba(7, 12, 27, 0.96)) !important;
+  box-shadow:
+    0 0 0 1px rgba(148, 163, 184, 0.085),
+    0 24px 70px rgba(0, 0, 0, 0.28) !important;
+}
+
+.jobs-empty-title {
+  text-wrap: balance;
+}
+
+.jobs-empty-message {
+  text-wrap: pretty;
+}
+
+.jobs-empty-icon {
+  border-color: color-mix(in srgb, var(--border-subtle) 82%, transparent) !important;
+  background: color-mix(in srgb, var(--surface-muted) 76%, transparent) !important;
+  color: color-mix(in srgb, var(--brand) 56%, var(--text-muted)) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    0 10px 26px rgba(31, 45, 74, 0.08) !important;
+}
+
+.dark .jobs-empty-icon {
+  border-color: rgba(148, 163, 184, 0.09) !important;
+  background: rgba(15, 23, 42, 0.48) !important;
+  color: rgba(129, 140, 248, 0.54) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.035),
+    0 12px 30px rgba(0, 0, 0, 0.18) !important;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { TestModeBanner } from "@/components/admin/TestModeBanner";
 import { getCurrentSessionAndProfile } from "@/lib/auth";
 import { normalizeThemePreference, type ThemePreference } from "@/lib/theme-preference";
 import "./globals.css";
+import "./jobs-polish.css";
 
 const fontSans = Plus_Jakarta_Sans({
   variable: "--font-sans",

--- a/src/components/jobs/JobsList.tsx
+++ b/src/components/jobs/JobsList.tsx
@@ -291,8 +291,9 @@ export function JobsList({
 
                 <button
                     onClick={() => setShowFilterPanel(true)}
+                    data-active={showFilterPanel || hasChanges}
                     className={cn(
-                        "jobs-filter-trigger relative ml-4 flex items-center gap-2.5 whitespace-nowrap rounded-xl border border-transparent px-3.5 py-2.5 text-slate-400 transition-colors duration-200 hover:border-white/10 hover:bg-white/5 hover:text-white sm:px-4",
+                        "jobs-filter-trigger relative ml-4 flex items-center gap-2.5 whitespace-nowrap rounded-full border border-transparent px-3.5 py-2.5 text-slate-400 transition-[background-color,border-color,color,box-shadow,transform] duration-200 ease-out active:scale-[0.96] sm:px-4",
                         showFilterPanel && "bg-white/10 text-indigo-300 border-indigo-500/20",
                         hasChanges && !showFilterPanel && "text-indigo-300 border-indigo-500/20 bg-indigo-500/10"
                     )}
@@ -322,7 +323,7 @@ export function JobsList({
                                 emptyMsg={
                                     <EmptyState
                                         icon={Briefcase}
-                                        title="Aktuell keine lokalen Jobs"
+                                        title="Keine lokalen Jobs gefunden"
                                         message={
                                             hasChanges
                                                 ? "Keine lokalen Jobs für deine aktuellen Filter. Versuche, die Filter anzupassen."
@@ -515,12 +516,12 @@ function EmptyState({
     message: string;
 }) {
     return (
-        <div className="jobs-empty-copy flex flex-col items-center justify-center space-y-4 px-4 py-8">
-            <div className="jobs-empty-icon flex h-16 w-16 items-center justify-center rounded-2xl border border-white/[0.05] bg-slate-900/60 text-indigo-400/80">
-                <Icon size={26} className="opacity-80" />
+        <div className="jobs-empty-copy flex flex-col items-center justify-center space-y-3 px-4 py-8">
+            <div className="jobs-empty-icon flex h-12 w-12 items-center justify-center rounded-[0.95rem] border border-white/[0.05] bg-slate-900/40 text-indigo-300/50">
+                <Icon size={20} className="opacity-[0.62]" />
             </div>
-            <div className="text-center space-y-1.5">
-                <h3 className="jobs-empty-title text-xl font-bold tracking-tight text-white">{title}</h3>
+            <div className="space-y-1.5 text-center">
+                <h3 className="jobs-empty-title text-lg font-bold leading-tight tracking-tight text-white">{title}</h3>
                 <p className="jobs-empty-message mx-auto max-w-sm text-sm leading-relaxed text-slate-400">{message}</p>
             </div>
         </div>

--- a/src/components/jobs/JobsListSection.tsx
+++ b/src/components/jobs/JobsListSection.tsx
@@ -50,8 +50,8 @@ export const JobsListSection = memo(function JobsListSection({
 
             <div className="jobs-card-grid grid grid-cols-1 gap-6 lg:grid-cols-2">
                 {jobs.length === 0 ? (
-                    <div className="jobs-empty-state col-span-full rounded-[1.35rem] border border-white/10 bg-white/[0.025] py-10 text-center">
-                        <div className="text-slate-400">{emptyMsg}</div>
+                    <div className="jobs-empty-state col-span-full flex min-h-[17.5rem] items-center justify-center overflow-hidden rounded-[1.5rem] border-0 px-5 py-10 text-center">
+                        <div className="w-full">{emptyMsg}</div>
                     </div>
                 ) : (
                     jobs.map(job => (


### PR DESCRIPTION
## Summary

- polish the empty local jobs state so the window feels more modern and stable
- remove the distracting top hairline artifact and soften the centered empty-state icon
- update the empty-state headline to "Keine lokalen Jobs gefunden"

## Validation

- npm run lint
