### PR TITLE
Fix public legal redirect behind reverse proxy

### DIFF
--- a/src/app/legal/route.ts
+++ b/src/app/legal/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
 export function GET(request: Request) {
-  return NextResponse.redirect(new URL("/legal/impressum", request.url), 307);
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? request.url;
+  return NextResponse.redirect(new URL("/legal/impressum", baseUrl), 307);
 }


### PR DESCRIPTION
## Änderung
- verwendet die konfigurierte öffentliche Basis-URL für `/legal`
- verhindert Weiterleitungen auf die interne Container-Adresse hinter Cloudflare Tunnel/Traefik

## Prüfung
- 11 Tests erfolgreich
- TypeScript-Prüfung erfolgreich
- produktive Ziel-URL ist als `NEXT_PUBLIC_BASE_URL` konfiguriert